### PR TITLE
Adding searchRelevanceDashboards to artifacts

### DIFF
--- a/charts/opensearch-dashboards/plugins/artifacts.json
+++ b/charts/opensearch-dashboards/plugins/artifacts.json
@@ -3,6 +3,10 @@
     {
       "name": "mlCommonsDashboards",
       "url": "https://github.com/ruanyl/opensearch-dev-env/releases/download/artifacts.4770138978/mlCommonsDashboards.zip"
+    },
+    {
+      "name": "searchRelevanceDashboards",
+      "url": "https://github.com/sejli/dashboards-search-relevance/releases/download/2.7.0-experimental.4962415831/searchRelevanceDashboards-2.7.0.zip"
     }
   ]
 }


### PR DESCRIPTION
Created experimental release for [dashboards-search-relevance](https://github.com/opensearch-project/dashboards-search-relevance) following [ml commons example](https://github.com/ruanyl/ml-commons-dashboards/actions/runs/4752943440/workflow).

Included in my fork is the [displaying images feature](https://github.com/opensearch-project/dashboards-search-relevance/issues/195)