### PR TITLE
Update dashboards-search-relevance plugin

### DIFF
--- a/charts/opensearch-dashboards/plugins/artifacts.json
+++ b/charts/opensearch-dashboards/plugins/artifacts.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "searchRelevanceDashboards",
-      "url": "https://github.com/sejli/dashboards-search-relevance/releases/download/2.7.0-experimental.4962415831/searchRelevanceDashboards-2.7.0.zip"
+      "url": "https://github.com/sejli/dashboards-search-relevance/releases/download/2.7.0-experimental.5016577303/searchRelevanceDashboards-2.7.0.zip"
     }
   ]
 }


### PR DESCRIPTION
Adding features for displaying images in `dashboards-search-relevance` plugin