### PR TITLE
filtering index in search comparison tool

### DIFF
--- a/charts/opensearch-dashboards/plugins/artifacts.json
+++ b/charts/opensearch-dashboards/plugins/artifacts.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "searchRelevanceDashboards",
-      "url": "https://github.com/ruanyl/opensearch-dev-env/releases/download/artifacts-5627785090/searchRelevanceDashboards.zip"
+      "url": "https://github.com/sejli/dashboards-search-relevance/releases/download/2.7.0-experimental.5662283360/searchRelevanceDashboards-2.7.0.zip"
     }
   ]
 }


### PR DESCRIPTION
use the document `allowlist_indices` in the `configurations` index to specify which indices users can use in the Search Comparison Tool